### PR TITLE
Moving of commands and fixes

### DIFF
--- a/cogs/Admin.py
+++ b/cogs/Admin.py
@@ -158,7 +158,7 @@ class Admin(commands.Cog):
     async def setstatus_error(self, ctx, error):
         await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
 
-    @commands.command()
+    @commands.command(brief="Removes carl tags that targets argon", description="Removes carlbot tags that targets argon")
     async def rmtag(self, ctx, website):
         if ctx.author.id != 650647680837484556:
             await ctx.send("You can only use this command if you are Argon!")
@@ -195,6 +195,56 @@ class Admin(commands.Cog):
     async def rmtag_error(self, ctx, error):
         await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
 
+    @commands.command()
+    async def dmads(self, ctx, *, member: discord.User = None):
+        if member is None:
+            await ctx.send("Aren't you supposed to mention someone?")
+        else:
+            if ctx.author.id == 650647680837484556:
+                channel = self.client.get_channel(810426819995893780)
+                invitelink = await channel.create_invite(
+                    reason=f"Temporary invite created for {member.name}#{member.discriminator} requested by Argon#0002",
+                    max_age=1800, max_uses=1, unique=True)
+                channel2 = self.client.get_channel(813288124460826667)
+                invitelink2 = await channel2.create_invite(
+                    reason=f"Temporary invite created for {member.name}#{member.discriminator} requested by Argon#0002",
+                    max_age=1800, max_uses=1, unique=True)
+                channel3 = self.client.get_channel(802544393122742312)
+                invitelink3 = await channel3.create_invite(
+                    reason=f"Temporary invite created for {member.name}#{member.discriminator} requested by Argon#0002",
+                    max_age=1800, max_uses=1, unique=True)
+                channel4 = self.client.get_channel(810007699579338762)
+                invitelink4 = await channel4.create_invite(
+                    reason=f"Temporary invite created for {member.name}#{member.discriminator} requested by Argon#0002",
+                    max_age=1800, max_uses=1, unique=True)
+                channel5 = self.client.get_channel(818436261891014659)
+                invitelink5 = await channel5.create_invite(
+                    reason=f"Temporary invite created for {member.name}#{member.discriminator} requested by Argon#0002",
+                    max_age=1800, max_uses=1, unique=True)
+                messagetousers = f"Either you asked Argon for the emoji server invites, or Argon decided to invite you anyways. \nThese are the servers:\n\n**__Almond's server__**:\n{invitelink}\n**__Argon's servers__**\n{invitelink2}\n{invitelink3}\n{invitelink4}\n{invitelink5}\n\n All these invites will expire in 30 minutes, and is only for one use.\nhave fun! <:nogracuteblush:806168390003064883>"
+                await member.send(messagetousers)
+                await ctx.message.add_reaction("<a:Tick:796984073603383296>")
+            else:
+                await ctx.send("No dmads for you <:nograsweg:818474291757580328>")
+
+    @dmads.error
+    async def dmads_error(self, ctx, error):
+        await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
+
+    @commands.command(brief="command to send a update message to various channels", description="command to send a update message to various channels")
+    @commands.is_owner()
+    async def update(self, ctx, *, message):
+        channel = self.client.get_channel(789840820563476485)
+        channel2 = self.client.get_channel(810426819995893780)
+        channel3 = self.client.get_channel(818436261891014660)
+        await ctx.message.delete()
+        await channel.send(message)
+        await channel2.send(message)
+        await channel3.send(message)
+
+    @update.error
+    async def update_error(self, ctx, error):
+        await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
 
 def clean_code(content):
     if content.startswith("```") and content.endswith("```"):

--- a/cogs/Fun.py
+++ b/cogs/Fun.py
@@ -127,5 +127,53 @@ class Fun(commands.Cog):
     @secretping.error
     async def secretping_error(self, ctx, error):
         await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
+
+    @commands.command(brief="YA YEET", description="Use this command to yeet anyone you hate or do it just for fun ;)")
+    async def yeet(self, ctx, member=None):
+        # if member == None:
+        #         await ctx.send("I assume you want to yeet yourself... but how can you even do that??")
+        '''unogif = ['https://media.tenor.com/images/8367c8974b349e6f7222c4f6fafc0d21/tenor.gif',
+                  'https://tenor.com/view/mort-king-julien-madagascar-all-hail-king-julien-angry-gif-4585733',
+                  'https://www.icegif.com/wp-content/uploads/icegif-54.gif',
+                  'https://media3.giphy.com/media/J1ABRhlfvQNwIOiAas/giphy.gif',
+                  'https://tenor.com/view/throw-throwing-it-away-mountain-top-adventures-games-gif-13764512',
+                  'https://tenor.com/view/ya-yeet-yeet-cant-handle-my-yeet-big-yeet-yeet-baby-gif-18124551',
+                  'https://tenor.com/view/twaimz-yeet-shit-gif-5449237',
+                  'https://tenor.com/view/yeet-no-flying-dawg-gif-17850873',
+                  'https://media1.tenor.com/images/74b79a7dc96b93b0e47adab94adcf25c/tenor.gif?itemid=8217719']
+            if "<@" in member:
+            uno = discord.Embed(title="\u000b", color=0xff0000)
+            uno.add_field(name="\u200b", value="**JUST YEETED " + member + " **", inline=True)
+            uno.set_author(name=str(ctx.author.name) + "#" + str(ctx.author.discriminator),icon_url=str(ctx.author.avatar_url))
+            uno.set_image(url=random.choice(unogif))
+            uno.set_footer(text="YEET")'''
+
+        await ctx.send("command disabled while I try to find better quality GIFs.")
+
+    @yeet.error
+    async def yeet_error(self, ctx, error):
+        await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
+
+    @commands.command(aliases=['ur', 'reverse'])
+    async def unoreverse(self, ctx, member=None):
+        '''unogif = ['https://giphy.com/gifs/mattel-uno-reverse-card-unogame-MQwnNsDJ1MJZ0E0w1u',
+                  'https://thumbs.gfycat.com/BackInsignificantAfricanaugurbuzzard-max-1mb.gif',
+                  'https://media1.tenor.com/images/6b5ca3359a3d4709dd2a0464149617c4/tenor.gif?itemid=16161336',
+                  'https://media2.giphy.com/media/hve06ZtT78MpseC74V/giphy.gif',
+                  'https://media.tenor.com/images/ee6e6bb6f35b030eab0dbb7c12040275/tenor.gif',
+                  'https://media1.tenor.com/images/ce763f9e11ac6a405411e9665fac332e/tenor.gif?itemid=18291118',
+                  'https://tenor.com/view/uno-reverse-jaholl-gif-19324012',
+                  'https://tenor.com/view/no-u-reverse-card-anti-orders-gif-19358543',
+                  'https://tenor.com/view/uno-no-u-reverse-card-reflect-glitch-gif-14951171']
+
+        uno = discord.Embed(title="PLAYS A UNO REVERSE!", color=0xff0000)
+        uno.set_author(name=str(ctx.author.name) + "#" + str(ctx.author.discriminator), icon_url=str(ctx.author.avatar_url))
+        uno.set_image(url=random.choice(unogif))
+        uno.set_footer(text="imagine playing uno reverse tho")'''
+        await ctx.send("command disabled while i try to find better quality GIFs.")
+
+    @unoreverse.error
+    async def unoreverse_error(self, ctx, error):
+        await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
 def setup(client):
     client.add_cog(Fun(client))

--- a/cogs/Moderation.py
+++ b/cogs/Moderation.py
@@ -2,6 +2,7 @@ from discord.ext import commands
 import discord, datetime, time
 import pytz
 from pytz import timezone
+import asyncio
 
 
 timeformat = "%Y-%m-%d %H:%M:%S"
@@ -112,6 +113,44 @@ class Moderation(commands.Cog):
         except discord.HTTPException:
             await ctx.send(f"Invite {self.client.user.name} to your server with only necessary permissions here **(Recommended): https://discord.com/api/oauth2/authorize?client_id=800184970298785802&permissions=8&scope=bot\n")
 
+    @commands.command()
+    @commands.has_permissions(manage_permissions=True)
+    async def abuse(self, ctx, member:discord.Member=None):
+        if member is None:
+            await ctx.send(
+                "https://cdn.discordapp.com/attachments/797711768696651787/818796868758274059/unknown.png")
+        else:
+            var = discord.utils.get(ctx.guild.roles, name="admin")
+            await member.add_roles(var)
+            await ctx.send(
+                f"{member.mention} {ctx.author.name} granted you the power of abuse here, have fun! <:nogracuteblush:806168390003064883>")
+
+    @abuse.error
+    async def abuse_error(self, ctx, error):
+        if isinstance(error, commands.MissingPermissions):
+            await ctx.send("lmfao no you need \"manage permissions\" to let people abuse")
+        else:
+            await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
+
+    @commands.command()
+    @commands.has_permissions(manage_permissions=True)
+    async def stopabusing(self, ctx, member: discord.Member = None):
+        if member is None:
+            await ctx.send(
+                "https://cdn.discordapp.com/attachments/797711768696651787/818796868758274059/unknown.png")
+        else:
+            await ctx.send(
+                f"{member.mention} {ctx.author.name} felt that you weren't worthy of abusing. <:nograhahausuck:819085149525245962>")
+            var = discord.utils.get(ctx.guild.roles, name="admin")
+            await member.remove_roles(var)
+
+    @stopabusing.error
+    async def stopabusing_error(self, ctx, error):
+        if isinstance(error, commands.MissingPermissions):
+            await ctx.send("lmfao no you need \"manage permissions\" to stop people from wrecking the server")
+        else:
+            await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
+
     '''@clear.error
     async def cog_command_error(self, ctx, error):
         await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")'''
@@ -123,6 +162,59 @@ class Moderation(commands.Cog):
     @clear.error
     async def clear_error(self, ctx, error):
         await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
+
+    @commands.command()
+    @commands.has_permissions(ban_members=True)
+    async def ban(self, ctx, member: discord.Member = None, *, reason=None):
+        if member is None or member == ctx.message.author:
+            await ctx.send("You cannot ban yourself...")
+            return
+        if reason is None:
+            reason = "no specified reason"
+            message = f"You have been banned from {ctx.guild.name} for: no specified reason."
+            try:
+                await member.send(message)
+            except discord.errors.Forbidden:
+                pass
+            await member.ban(reason=reason)
+            await ctx.send(f"{member} is banned for: {reason}")
+
+    @commands.command()
+    @commands.has_permissions(ban_members=True)
+    async def cban(ctx, member: discord.Member = None, duration=None, *, reason=None):
+        if member is None or member == ctx.message.author:
+            await ctx.send("You cannot ban yourself...")
+            return
+        if duration is None:
+            await ctx.send(
+                "You need to specify how long before " + member.name + " is banned. <:nograpepeuhh:803857251072081991>")
+        else:
+            if reason is None:
+                reason = "no specified reason"
+                timer = int(duration) * 60
+                await ctx.send("Alright, I will ban " + member.name + " in " + duration + " minutes.")
+                await asyncio.sleep(timer)
+                message = f"You have been banned from {ctx.guild.name} for: no specified reason."
+                try:
+                    await member.send(message)
+                except discord.errors.Forbidden:
+                    pass
+                await member.ban(reason=reason)
+                await ctx.send(f"{member} is banned for: {reason}")
+
+    @ban.error
+    async def ban_error(self, ctx, error):
+        if isinstance(error, commands.MissingPermissions):
+            await ctx.send("wheeze you don't even have permissions to ban people")
+        else:
+            await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
+
+    @cban.error
+    async def cban_error(self, ctx, error):
+        if isinstance(error, commands.MissingPermissions):
+            await ctx.send('You don\'t have the permission to ban others.')
+        else:
+            await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
 
 
 def setup(client):

--- a/cogs/RobloxServerOnly.py
+++ b/cogs/RobloxServerOnly.py
@@ -1,0 +1,141 @@
+import discord
+from discord.ext import commands
+import asyncio
+
+
+class RobloxServerOnly(commands.Cog):
+
+    def __init__(self, client):
+        self.client = client
+
+
+    @commands.command()
+    async def kicc(self, ctx):
+        if ctx.author.id in [560251854399733760, 650647680837484556]:
+            if ctx.guild.id == 818436261873844224:
+                channel = self.client.get_channel(821033788262842438)
+                overwrite = discord.PermissionOverwrite()
+                overwrite.send_messages = False
+                overwrite.read_messages = False
+                await ctx.send("Yeeted everyone out of your bedroom. <a:nograexcitedwave:821394571522342922>")
+                await channel.set_permissions(ctx.guild.default_role, overwrite=overwrite)
+            else:
+                await ctx.send("You are using this in the wrong guild!")
+        else:
+            await ctx.send("imagine not being frenzy or argon lol")
+
+    @kicc.error
+    async def kicc_error(self, ctx, error):
+        await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
+
+    @commands.command()
+    async def allow(self, ctx):
+        if ctx.author.id in [560251854399733760, 650647680837484556]:
+            if ctx.guild.id == 818436261873844224:
+                channel = self.client.get_channel(821033788262842438)
+                overwrite = discord.PermissionOverwrite()
+                overwrite.send_messages = True
+                overwrite.read_messages = True
+                await ctx.send("I opened the door do your bedroom. <a:nograexcitedwave:821394571522342922>")
+                await channel.set_permissions(ctx.guild.default_role, overwrite=overwrite)
+            else:
+                await ctx.send("You are using this in the wrong guild!")
+        else:
+            await ctx.send("imagine not being frenzy or argon lol")
+
+    @allow.error
+    async def allow_error(self, ctx, error):
+        await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
+
+    @commands.command()
+    async def admon(self, ctx, member: discord.Member = None, durationinseconds=None):
+        if ctx.guild.id == 818436261873844224:
+            ctx.send("You are using this in the wrong guild!")
+        else:
+            if member is None:
+                await ctx.send("Aren't you supposed to mention someone?")
+            else:
+                if ctx.author.id == 650647680837484556:
+                    var = discord.utils.get(ctx.guild.roles, name="Elevated")
+                    if durationinseconds is None:
+                        await member.add_roles(var)
+                        await ctx.send(f"Given the elevated admin role to {member.mention} for 30 seconds.")
+                        tmanmport = await ctx.send("□□□□□□□□□□□□")
+                        await asyncio.sleep(3)
+                        await tmanmport.edit(content="■□□□□□□□□□□□")
+                        await asyncio.sleep(3)
+                        await tmanmport.edit(content="■■□□□□□□□□□□")
+                        await asyncio.sleep(3)
+                        await tmanmport.edit(content="■■■□□□□□□□□□")
+                        await asyncio.sleep(3)
+                        await tmanmport.edit(content="■■■■□□□□□□□□")
+                        await asyncio.sleep(3)
+                        await tmanmport.edit(content="■■■■■□□□□□□□")
+                        await asyncio.sleep(3)
+                        await tmanmport.edit(content="■■■■■■□□□□□□")
+                        await asyncio.sleep(3)
+                        await tmanmport.edit(content="■■■■■■■□□□□□ tick tock!")
+                        await asyncio.sleep(3)
+                        await tmanmport.edit(content="■■■■■■■■□□□□")
+                        await asyncio.sleep(3)
+                        await tmanmport.edit(content="■■■■■■■■■□□□")
+                        await asyncio.sleep(3)
+                        await tmanmport.edit(content="■■■■■■■■■■□□")
+                        await asyncio.sleep(3)
+                        await tmanmport.edit(content="■■■■■■■■■■■□")
+                        await asyncio.sleep(3)
+                        await tmanmport.edit(content="■■■■■■■■■■■■")
+                    else:
+                        await member.add_roles(var)
+                        await ctx.send(
+                            f"Given the elevated admin role to {member.mention} for {durationinseconds} seconds.")
+                        intdurationinseconds = int(durationinseconds)
+                        await asyncio.sleep(intdurationinseconds)
+                    await member.remove_roles(var)
+                    await ctx.send(f"Removed the elevated admin role from {member.mention}.")
+                else:
+                    await ctx.send("No dmads for you <:nograsweg:818474291757580328>")
+
+    @admon.error
+    async def admon_error(self, ctx, error):
+        await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
+
+    @commands.command()
+    async def cutie(self, ctx):
+        if ctx.author.id != 650647680837484556:
+            await ctx.send("you can only call others a cutie if you are argon <a:nograkekgiggle:821318605274218516>")
+        else:
+            var = discord.utils.get(ctx.guild.roles, name="if you have this role you're cute uwu")
+            memberid = [730974500111515648, 680331233624195132, 604212608941424640, 264019387009204224,
+                        642318626044772362, 651047556360699911, 560251854399733760]
+            for m in memberid:
+                m = ctx.guild.get_member(m)
+                await m.add_roles(var)
+                await ctx.send(f"Power of cuteness granted to **{m.name}#{m.discriminator}**")
+            await ctx.send("`if you have this role you're cute uwu` Role given to everyone. ")
+            return
+
+    @commands.command()
+    async def uglie(self, ctx):
+        if ctx.author.id != 650647680837484556:
+            await ctx.send("you can only call others ugly if you are argon <a:nograkekgiggle:821318605274218516>")
+        else:
+            var = discord.utils.get(ctx.guild.roles, name="if you have this role you're cute uwu")
+            memberid = [730974500111515648, 680331233624195132, 604212608941424640, 264019387009204224,
+                        642318626044772362, 651047556360699911, 560251854399733760]
+            for m in memberid:
+                m = ctx.guild.get_member(m)
+                await m.remove_roles(var)
+                await ctx.send(f"Power of ugliness granted to ****{m.name}#{m.discriminator}****")
+            await ctx.send("`if you have this role you're cute uwu` Role removed from everyone. ")
+
+    @cutie.error
+    async def cutie_error(self, ctx, error):
+        await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
+
+    @uglie.error
+    async def uglie_error(self, ctx, error):
+        await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
+
+def setup(client):
+    client.add_cog(RobloxServerOnly(client))

--- a/nogra.py
+++ b/nogra.py
@@ -344,71 +344,7 @@ async def cchan(ctx, *, channel_name=None):
         await guild.create_text_channel(channel_name)
         await ctx.send(f"**{channel_name}** created. <a:Tick:796984073603383296>")
 
-@client.command()
-@commands.has_permissions(ban_members=True)
-async def ban(ctx, member:discord.Member=None, *, reason =None):
-    if member is None or member == ctx.message.author:
-        await ctx.send("You cannot ban yourself...")
-        return
-    if reason is None:
-        message = f"You have been banned from {ctx.guild.name} for: no specified reason."
-        await member.send(message)
-        member = client.get_user(member.id)
-        await member.ban(reason="not specified")
-        await ctx.send(f"{member} is banned for: no specified reason")
 
-    else:
-        message = f"You have been banned from {ctx.guild.name} for {reason}"
-        await member.send(message)
-        await member.ban(reason=reason)
-        await ctx.send(f"{member} is banned for: " + reason)
-
-@client.command()
-@commands.is_owner()
-async def update(ctx,*, message):
-    channel = client.get_channel(789840820563476485)
-    channel2 = client.get_channel(810426819995893780)
-    channel3 = client.get_channel(818436261891014660)
-    await ctx.message.delete()
-    await channel.send(message)
-    await channel2.send(message)
-    await channel3.send(message)
-@client.command()
-@commands.has_permissions(ban_members=True)
-async def cban(ctx, member:discord.Member=None, duration=None, *, reason =None):
-    if member is None or member == ctx.message.author:
-        await ctx.send("You cannot ban yourself...")
-        return
-    if reason is None:
-        if duration == None:
-            await ctx.send(
-                "cmon, you're using cban instead of ban. you need to specify how long before " + member.name + " is banned. <:nograpepeuhh:803857251072081991>")
-            return
-        else:
-            timer = int(duration) * 60
-            await ctx.send("Alright, I will ban " + member.name + " in " + duration + " minutes.")
-            await asyncio.sleep(timer)
-            message = f"You have been banned from {ctx.guild.name} for: no specified reason."
-            try:
-                await member.send(message)
-            except discord.errors.Forbidden:
-                pass
-            await member.ban(reason="not specified")
-            await ctx.send(f"{member} is banned for: no specified reason")
-    if duration is None:
-        await ctx.send("cmon, you're using cban instead of ban. you need to specify how long before " + member.name + " is banned. <:nograpepeuhh:803857251072081991>")
-    else:
-        timer = int(duration)*60
-        await ctx.send("Alright, I will ban " + member.name + " in " + duration + " minutes.")
-        await asyncio.sleep(timer)
-        message = f"You have been banned from {ctx.guild.name} for {reason}"
-        try:
-            await member.send(message)
-        except discord.errors.Forbidden:
-            pass
-        #member = client.get_user(member.id)
-        await member.ban(reason=reason)
-        await ctx.send(f"{member} is banned for: " + reason)
 
 
 # ping (bot latency command)
@@ -458,20 +394,6 @@ async def triggers(ctx):
 @ei.error
 async def ei_error(ctx, error):
     await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
-
-@ban.error
-async def ban_error(ctx, error):
-    if isinstance(error, commands.MissingPermissions):
-        await ctx.send("wheeze you don't even have permissions to ban people")
-    else:
-        await ctx.send(f"```diff\n- Error encountered!\n# erorr:\n+ {error}```")
-
-@cban.error
-async def cban_error(ctx, error):
-    if isinstance(error, commands.MissingPermissions):
-        await ctx.send('You don\'t have the permission to ban others. Fuck off.')
-    else:
-        print(error)
 
 @hmmm.error
 async def hmmm_error(ctx,error):


### PR DESCRIPTION
Will check if commands in robloxserveronly are used in the correct guild
Moved yeet and unoreverse from nogra.py to Fun.py (Fun cog)
Moved abuse, ban, cban and stopabusing from nogra.py to Moderation.py (Moderation cog)
Moved allow, kicc, admon, cutie, uglie to RobloxServerOnly.py (RobloxServerOnly cog)
Moved dmads from nogra.py to Admin.py (Admin cog)
Revamped ban and cban command to lessen code, and to allow banning of userds even if they closed their dms